### PR TITLE
change number type to `long long`

### DIFF
--- a/fraux.c
+++ b/fraux.c
@@ -73,7 +73,7 @@ static int fraux_parse_number(fraux_conext *c, fraux_value *v)
         return FRAUX_PARSE_INVALID_VALUE;
     }
 
-    v->u.n = strtol(c->bencode + c->pos + 1, NULL, 10);
+    v->u.n = strtoll(c->bencode + c->pos + 1, NULL, 10);
     v->type = FRAUX_NUMBER;
     c->pos += p;
 
@@ -244,7 +244,7 @@ static void fraux_stringtify_value(fraux_conext *c, fraux_value *v)
     switch (v->type)
     {
     case FRAUX_NUMBER:
-        c->stack.top -= 32 - sprintf(fraux_conext_push(c, 32), "i%lde", v->u.n);
+        c->stack.top -= 32 - sprintf(fraux_conext_push(c, 32), "i%llde", v->u.n);
         break;
     case FRAUX_STRING:
         c->stack.top -= 32 - sprintf(fraux_conext_push(c, 32), "%ld:", v->u.s.len);
@@ -430,7 +430,7 @@ fraux_type fraux_get_type(fraux_value *v)
     return v->type;
 }
 
-void fraux_set_number(fraux_value *v, long int num)
+void fraux_set_number(fraux_value *v, long long num)
 {
     assert(v != NULL);
     fraux_init(v);

--- a/fraux.h
+++ b/fraux.h
@@ -20,7 +20,7 @@ typedef struct fraux_value
 {
     fraux_type type;
     union {
-        long int n;
+        long long n;
         struct bstring
         {
             char *s;
@@ -65,7 +65,7 @@ int fraux_equals(fraux_value *v1, fraux_value *v2);
 fraux_type fraux_get_type(fraux_value *v);
 
 /* set value */
-void fraux_set_number(fraux_value *v, long int num);
+void fraux_set_number(fraux_value *v, long long num);
 void fraux_set_string(fraux_value *v, const char *s, size_t len);
 void fraux_set_list(fraux_value *v, size_t capacity);
 void fraux_set_dictionary(fraux_value *v, size_t capacity);


### PR DESCRIPTION
操作系统: Windows 7
编译器: MinGW-W64-builds-4.3.5

测试样例 `STRINGTIFY_TEST("i3232545342e", 12)` 无法通过.

错误原因是编译器的 `long int` 长度为 4 字节, 测试样例的数值超出范围.
建议改为固定 8 字节的 `long long` 类型.